### PR TITLE
feat: Implement timed button mash skill challenge

### DIFF
--- a/spa_complete_game (1).html
+++ b/spa_complete_game (1).html
@@ -558,6 +558,31 @@
             background: linear-gradient(135deg, #95a5a6, #7f8c8d);
         }
 
+        .progress-bar-container {
+            width: 100%;
+            height: 30px;
+            background-color: #555;
+            border-radius: 15px;
+            margin-bottom: 15px;
+            overflow: hidden;
+            border: 2px solid #777;
+        }
+
+        .progress-bar {
+            width: 0%;
+            height: 100%;
+            background-color: #2ecc71;
+            transition: width 0.1s linear;
+            text-align: center;
+            line-height: 30px;
+            color: white;
+            font-weight: bold;
+        }
+
+        .progress-bar.stress {
+            background-color: #e74c3c;
+        }
+
         /* Responsive Design */
         @media (max-width: 768px) {
             .menu-box {
@@ -868,7 +893,7 @@
                         "image": "cutscene_01_c.png"
                     }
                 ],
-                "nextChallengeId": "challenge_01"
+                "nextChallengeId": "timed_button_mash"
             },
             "cutscene_02": {
                 "title": "La Prova Superata",
@@ -876,6 +901,15 @@
                     {
                         "narrative": "Con la prova superata, un nuovo sentiero si illumina davanti a te. L'avventura continua...",
                         "image": "cutscene_02_a.png"
+                    }
+                ]
+            },
+            "cutscene_game_over": {
+                "title": "Game Over",
+                "slides": [
+                    {
+                        "narrative": "La tua avventura finisce qui. Ma non temere, ogni fine è un nuovo inizio.",
+                        "image": "game_over.png"
                     }
                 ]
             }
@@ -887,6 +921,18 @@
                 "description": "Supera questa semplice prova per continuare la tua avventura.",
                 "type": "simple_click",
                 "successCutscene": "cutscene_02"
+            },
+            "timed_button_mash": {
+                "title": "Prova di Controllo",
+                "description": "Premi il pulsante per caricare l'energia. Non superare il limite o il sistema andrà in sovraccarico!",
+                "type": "timed_button_mash",
+                "targetHits": 20,
+                "maxStress": 100,
+                "hitPower": 1,
+                "stressPower": 10,
+                "stressDecay": 2,
+                "successCutscene": "cutscene_02",
+                "failureCutscene": "cutscene_game_over"
             }
         };
 
@@ -1082,6 +1128,54 @@
                 button.textContent = 'Clicca per vincere!';
                 button.onclick = () => completeChallenge(challengeId);
                 contentArea.appendChild(button);
+            } else if (challenge.type === 'timed_button_mash') {
+                contentArea.innerHTML = `
+                    <div>
+                        <span>Energia:</span>
+                        <div class="progress-bar-container">
+                            <div id="hits-progress" class="progress-bar">0%</div>
+                        </div>
+                    </div>
+                    <div>
+                        <span>Sovraccarico:</span>
+                        <div class="progress-bar-container">
+                            <div id="stress-progress" class="progress-bar stress">0%</div>
+                        </div>
+                    </div>
+                    <button id="challenge-button" class="player-name-button">Carica Energia</button>
+                `;
+
+                let currentHits = 0;
+                let currentStress = 0;
+                const challengeButton = document.getElementById('challenge-button');
+                const hitsProgress = document.getElementById('hits-progress');
+                const stressProgress = document.getElementById('stress-progress');
+
+                const gameLoop = setInterval(() => {
+                    currentStress -= challenge.stressDecay;
+                    if (currentStress < 0) currentStress = 0;
+
+                    stressProgress.style.width = `${(currentStress / challenge.maxStress) * 100}%`;
+                    stressProgress.textContent = `${Math.round(currentStress)}%`;
+
+                    if (currentStress >= challenge.maxStress) {
+                        clearInterval(gameLoop);
+                        failChallenge(challengeId);
+                    }
+                }, 100);
+
+                challengeButton.onclick = () => {
+                    currentHits += challenge.hitPower;
+                    currentStress += challenge.stressPower;
+
+                    hitsProgress.style.width = `${(currentHits / challenge.targetHits) * 100}%`;
+                    hitsProgress.textContent = `${Math.round((currentHits / challenge.targetHits) * 100)}%`;
+
+                    if (currentHits >= challenge.targetHits) {
+                        clearInterval(gameLoop);
+                        completeChallenge(challengeId);
+                    }
+                };
             }
 
             showSection('skill-challenge-section');
@@ -1091,6 +1185,18 @@
             const challenge = skillChallenges[challengeId];
             if (challenge.successCutscene) {
                 gameData.currentCutsceneId = challenge.successCutscene;
+                gameData.currentSlideIndex = 0;
+                loadCutscene(gameData.currentSlideIndex);
+                showSection('cutscene-section');
+            } else {
+                backToMainMenu();
+            }
+        }
+
+        function failChallenge(challengeId) {
+            const challenge = skillChallenges[challengeId];
+            if (challenge.failureCutscene) {
+                gameData.currentCutsceneId = challenge.failureCutscene;
                 gameData.currentSlideIndex = 0;
                 loadCutscene(gameData.currentSlideIndex);
                 showSection('cutscene-section');


### PR DESCRIPTION
This commit introduces a new skill challenge of type 'timed_button_mash' and integrates it into the game flow after the first cutscene.

Key changes:
- Added a new challenge definition to `skillChallenges` with parameters for hits, stress, and decay.
- Updated `cutscene_01` to trigger this new challenge.
- Added a `cutscene_game_over` for the failure case.
- Implemented the UI for the challenge, including progress bars for hits and stress.
- Added the core game logic for the timed button mash, including a game loop and success/failure conditions.
- Created a `failChallenge` function to handle the failure state transition.