### PR TITLE
fix: Correctly load cutscenes by ID

### DIFF
--- a/spa_complete_game (1).html
+++ b/spa_complete_game (1).html
@@ -1059,7 +1059,7 @@
             gameData.player.location = 'cutscene-section';
             saveGameState();
 
-            const cutscene = cutsceneData.cutscene_01;
+            const cutscene = cutsceneData[gameData.currentCutsceneId];
             if (cutscene && cutscene.slides && cutscene.slides.length > slideIndex) {
                 const slide = cutscene.slides[slideIndex];
                 


### PR DESCRIPTION
This commit fixes a critical bug where the `loadCutscene` function was always loading `cutscene_01` due to a hardcoded reference. The function now correctly uses `gameData.currentCutsceneId` to load the appropriate cutscene data.

This fix resolves the issue where the game would not progress correctly after the first cutscene or after completing a skill challenge.